### PR TITLE
fix wifi config error

### DIFF
--- a/0006-gecko-clear_addrs.patch
+++ b/0006-gecko-clear_addrs.patch
@@ -13,9 +13,10 @@ index df438c5..c331ad2 100644
  CommandFunc NetworkUtils::sWifiDisableChain[] = {
    NetworkUtils::clearWifiTetherParms,
 +  NetworkUtils::clearAddrs,
++  NetworkUtils::wifiFirmwareReload,
    NetworkUtils::stopSoftAP,
    NetworkUtils::stopAccessPointDriver,
-   NetworkUtils::wifiFirmwareReload,
+-  NetworkUtils::wifiFirmwareReload,
    NetworkUtils::untetherInterface,
    NetworkUtils::preTetherInterfaceList,
    NetworkUtils::postTetherInterfaceList,


### PR DESCRIPTION
when stop wifi ap mode(enable wifi), sometimes the loaded firmware is wrong for some netdev ioctls
(wext related: SIOCGIWRANGE, SIOCGIWSCAN...) are called in bad time.
Let's load the firmware more earlier.

Need more tests.

Signed-off-by: Jianmin Zhou toandrew@infthink.com
